### PR TITLE
Fixing "s.type is not a constructor" issue

### DIFF
--- a/AccountSwitcher.plugin.js
+++ b/AccountSwitcher.plugin.js
@@ -51,7 +51,7 @@ class AccountSwitcher {
 	}
 
 	loadStrings(){
-		var xmlHttp = new XMLHttpRequest();
+		let xmlHttp = new XMLHttpRequest();
 		xmlHttp.open("GET", 'https://raw.githubusercontent.com/l0c4lh057/AccountSwitcher/master/translations.json', false); // false for synchronous request
     	xmlHttp.send(null);
 		this.strings = JSON.parse(xmlHttp.responseText);


### PR DESCRIPTION
I was able to fix the [s.type is not a constructor issue](https://github.com/l0c4lh057/AccountSwitcher/issues/1) on my machine by replacing

```js
var xmlHttp = new XMLHttpRequest();
```
with
```js
let xmlHttp = new XMLHttpRequest();
```

according to the [javascript.info page for XMLHttpRequest](https://javascript.info/xmlhttprequest)

I am not aware of why this would work, but it solved the issue on my machine and may do so for others too.